### PR TITLE
Add Keyboard shortcuts

### DIFF
--- a/Scripts/Popup.js
+++ b/Scripts/Popup.js
@@ -5,33 +5,13 @@
     var presetsClass;
     var data;
 
-    document.addEventListener('DOMContentLoaded', () => {
-      chrome.storage.local.get(["presets"], results => {
-        if (results.presets !== undefined) {
-          data = results.presets;
-        data.sort(Compare);
-          Initialize();
-        } else {
-          let requestURL = '../Content/Data.json';
-          let request = new XMLHttpRequest();
-          request.open('GET', requestURL);
-          request.send();
 
-          request.onload = () => {
-            if (request.status === 200) {
-              data = JSON.parse(request.responseText).presets;
-              chrome.storage.local.set({
-                "presets": data
-              }, () => {
-                Initialize();
-              });
-            }
-          };
-        }
-      });
+    document.addEventListener('DOMContentLoaded', () => {
+      loadPresets(Initialize)
     });
 
-    function Initialize() {
+    function Initialize(loadedData) {
+      data = loadedData
       for (var i = 0; i < data.length; i++) {
         CreatePreset(data[i]);
       }
@@ -159,7 +139,7 @@
             btnEdit.classList.remove('editMode-cancel');
             btnEdit.state = undefined;
           }
-            data.sort(Compare);
+            data.sort(comparePresets);
           for (var i = 0; i < data.length; i++) {
             CreatePreset(data[i]);
           }
@@ -188,7 +168,7 @@
         let y = parseInt(e.target.getAttribute('data-top'));
         let w = parseInt(e.target.getAttribute('data-width'));
         let h = parseInt(e.target.getAttribute('data-height'));
-        ResizeWindow(x, y, w, h);
+        resizeWindow(x, y, w, h);
 
       }
     });
@@ -199,18 +179,6 @@
       while (main.firstChild) {
         main.removeChild(main.firstChild);
       }
-    }
-
-    function ResizeWindow(x, y, w, h) {
-      chrome.windows.getCurrent(function(wind) {
-        var updateInfo = {
-          left: screen.availLeft + Math.round(x / 100 * screen.availWidth),
-          top: screen.availTop + Math.round(y / 100 * screen.availHeight),
-          width:Math.round(w / 100 * screen.availWidth),
-          height:Math.round(h / 100 * screen.availHeight)
-        };
-        chrome.windows.update(wind.id, updateInfo, () => window.close());
-      });
     }
 
     function RemovePreset(dataID) {
@@ -225,14 +193,6 @@
       }, () => {
 
       });
-    }
-
-    function Compare(a, b) {
-      if (parseInt(a.sortorder) > parseInt(b.sortorder))
-        return 1;
-      if (parseInt(a.sortorder) < parseInt(b.sortorder))
-        return -1;
-      return 0;
     }
     resetPreset.addEventListener('click', () => {
       let dialogForReset = document.getElementsByClassName("dialogWrapper")[1];

--- a/Scripts/Resizer.js
+++ b/Scripts/Resizer.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var data
+
 function loadPresets(callback) {
   chrome.storage.local.get(["presets"], results => {
     if (results.presets !== undefined) {

--- a/Scripts/Resizer.js
+++ b/Scripts/Resizer.js
@@ -1,0 +1,49 @@
+'use strict'
+
+function loadPresets(callback) {
+  chrome.storage.local.get(["presets"], results => {
+    if (results.presets !== undefined) {
+     data = results.presets;
+      data.sort(comparePresets);
+     callback(data)
+    } else {
+     let requestURL = '../Content/Data.json';
+     let request = new XMLHttpRequest();
+     request.open('GET', requestURL);
+     request.send();
+
+     request.onload = () => {
+      if (request.status === 200) {
+       data = JSON.parse(request.responseText).presets;
+       chrome.storage.local.set({
+        "presets": data
+       }, () => {
+        callback(data)
+       });
+      }
+     };
+    }
+   });
+}
+
+
+function resizeWindow(x, y, w, h) {
+  chrome.windows.getCurrent(function(wind) {
+   var updateInfo = {
+    left: screen.availLeft + Math.round(x / 100 * screen.availWidth),
+    top: screen.availTop + Math.round(y / 100 * screen.availHeight),
+    width:Math.round(w / 100 * screen.availWidth),
+    height:Math.round(h / 100 * screen.availHeight)
+   };
+   chrome.windows.update(wind.id, updateInfo, () => window.close());
+  });
+ }
+ 
+
+ function comparePresets(a, b) {
+  if (parseInt(a.sortorder) > parseInt(b.sortorder))
+    return 1;
+  if (parseInt(a.sortorder) < parseInt(b.sortorder))
+    return -1;
+  return 0;
+}

--- a/Scripts/background.js
+++ b/Scripts/background.js
@@ -33,3 +33,21 @@ chrome.storage.local.get({
   const {name, version} = chrome.runtime.getManifest();
   chrome.runtime.setUninstallURL('http://add0n.com/feedback.html?name=' + name + '&version=' + version);
 }
+
+/**
+ * Add event listener for keyboard commands
+ */
+browser.commands.onCommand.addListener((name) => {
+  // Trigger the preset with the index corresponding to the last letter
+  // of the name of the keyboard shortcut triggered (as defined in manifest)
+  var triggered = parseInt(name.slice(-1), 10)
+
+  loadPresets(presets => {
+    var preset = presets[triggered]
+    let x = parseInt(preset.left)
+    let y = parseInt(preset.top)
+    let w = parseInt(preset.width)
+    let h = parseInt(preset.height)
+    resizeWindow(x, y, w, h);
+  })
+})

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
     "default_popup": "popup.html"
   },
   "background":{
-    "scripts":["Scripts/background.js"],
+    "scripts":["Scripts/Resizer.js", "Scripts/background.js"],
     "persistent":false
   },
   "permissions": [
@@ -27,6 +27,32 @@
     "gecko": {
       "id": "{5ab9d1ca-5eb0-41d5-95c3-e0d81b14a002}",
       "strict_min_version": "52.0"
+    }
+  },
+  "commands": {
+    "resize0": {
+      "description": "Resize to template #1",
+      "suggested_key": {
+        "default": "MacCtrl+F9"
+      }
+    },
+    "resize1": {
+      "description": "Resize to template #2",
+      "suggested_key": {
+        "default": "MacCtrl+F10"
+      }
+    },
+    "resize2": {
+      "description": "Resize to template #3",
+      "suggested_key": {
+        "default": "MacCtrl+F11"
+      }
+    },
+    "resize3": {
+      "description": "Resize to template #4",
+      "suggested_key": {
+        "default": "MacCtrl+F12"
+      }
     }
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -40,6 +40,7 @@
       </p>
     </div>
   </div>
+  <script src="Scripts/Resizer.js" charset="utf-8"></script>
   <script src="Scripts/Popup.js" charset="utf-8"></script>
   <script src="Scripts/Sortable.js" charset="utf-8"></script>
 


### PR DESCRIPTION
Hey Ray,

Thanks for the great extension, I use it all the time. I was missing keyboard shortcuts so I added some for the first four presets, mapped to Ctrl+F9 - Ctrl-F12, hope you like it. Users can also change keyboard shortcuts in Firefox extension settings. There is no license specified in the respository, you might want to add that, hope it's okay that I forked this.

So I factored out some of the functions from `Popup.js` in order to make them available in the background script as well and then added an event handler for the shortcuts in `background.js`.

Please say so if anything's missing here for you.

All the best,
Vincent